### PR TITLE
Add methods to detect Citus extension in a new Citus module

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,3 +6,9 @@ Rake::TestTask.new do |t|
   t.libs << "test"
   t.pattern = "test/**/*_test.rb"
 end
+
+task :citus_test
+Rake::TestTask.new(:citus_test) do |t|
+  t.libs << "test"
+  t.pattern = "test/**/*_test_citus.rb"
+end

--- a/lib/pghero.rb
+++ b/lib/pghero.rb
@@ -3,6 +3,7 @@ require "active_record"
 
 # methods
 require "pghero/methods/basic"
+require "pghero/methods/citus"
 require "pghero/methods/connections"
 require "pghero/methods/explain"
 require "pghero/methods/indexes"
@@ -46,6 +47,7 @@ module PgHero
   class << self
     extend Forwardable
     def_delegators :primary_database, :access_key_id, :analyze, :analyze_tables, :autoindex, :autovacuum_danger,
+      :citus_enabled?, :citus_readable?,
       :best_index, :blocked_queries, :connection_sources, :connection_stats,
       :cpu_usage, :create_user, :database_size, :db_instance_identifier, :disable_query_stats, :drop_user,
       :duplicate_indexes, :enable_query_stats, :explain, :historical_query_stats_enabled?, :index_caching,

--- a/lib/pghero/database.rb
+++ b/lib/pghero/database.rb
@@ -1,6 +1,7 @@
 module PgHero
   class Database
     include Methods::Basic
+    include Methods::Citus
     include Methods::Connections
     include Methods::Explain
     include Methods::Indexes

--- a/lib/pghero/methods/citus.rb
+++ b/lib/pghero/methods/citus.rb
@@ -1,0 +1,14 @@
+module PgHero
+  module Methods
+    module Citus
+      # It will only cache citus_enabled if it is true once.
+      def citus_enabled?
+        @citus_enabled ||= citus_readable?
+      end
+
+      def citus_readable?
+        select_one("SELECT EXISTS(SELECT * FROM pg_extension WHERE extname = 'citus')")
+      end
+    end
+  end
+end

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -35,4 +35,8 @@ class BasicTest < Minitest::Test
   def test_databases
     assert PgHero.databases[:primary].running_queries
   end
+
+  def test_no_citus
+    refute PgHero.citus_enabled?
+  end
 end

--- a/test/basic_test_citus.rb
+++ b/test/basic_test_citus.rb
@@ -1,0 +1,7 @@
+require_relative "test_citus_helper"
+
+class BasicCitusTest < Minitest::Test
+  def test_citus
+    assert PgHero.citus_enabled?
+  end
+end

--- a/test/test_citus_helper.rb
+++ b/test/test_citus_helper.rb
@@ -1,0 +1,13 @@
+require "bundler/setup"
+Bundler.require(:default)
+require "minitest/autorun"
+require "minitest/pride"
+require "pg_query"
+require "activerecord-import"
+
+# for Minitest < 5
+Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)
+
+ActiveRecord::Base.establish_connection adapter: "postgresql", database: "pghero_test"
+
+ActiveRecord::Migration.enable_extension "citus"


### PR DESCRIPTION
A new module called "Citus" is added to the base methods, and it contains the methods for detecting citus extension. 