### PR TITLE
Modify the methods in the Space module if Citus is enabled

### DIFF
--- a/test/basic_test_citus.rb
+++ b/test/basic_test_citus.rb
@@ -4,4 +4,12 @@ class BasicCitusTest < Minitest::Test
   def test_citus
     assert PgHero.citus_enabled?
   end
+
+  def test_database_size
+    assert PgHero.database_size
+  end
+
+  def test_relation_sizes
+    assert PgHero.relation_sizes
+  end
 end

--- a/test/test_citus_helper.rb
+++ b/test/test_citus_helper.rb
@@ -11,3 +11,41 @@ Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)
 ActiveRecord::Base.establish_connection adapter: "postgresql", database: "pghero_test"
 
 ActiveRecord::Migration.enable_extension "citus"
+
+# Add a worker
+ActiveRecord::Base.connection.execute("SELECT * from master_add_node('localhost',5433)")
+
+ActiveRecord::Migration.create_table :users, force: true do |t|
+  t.integer :city_id
+  t.integer :login_attempts
+  t.string :email
+  t.string :zip_code
+  t.boolean :active
+  t.timestamp :created_at
+  t.timestamp :updated_at
+end
+
+# Distribute a table
+ActiveRecord::Base.connection.execute("SELECT create_distributed_table('users','id')")
+
+# Create a distributed index
+ActiveRecord::Migration.add_index :users, :updated_at
+
+class User < ActiveRecord::Base
+end
+
+users =
+  5000.times.map do |i|
+    city_id = i % 100
+    {
+      city_id: city_id,
+      email: "person#{i}@example.org",
+      login_attempts: rand(30),
+      zip_code: i % 40 == 0 ? nil : "12345",
+      active: true,
+      created_at: Time.now - rand(50).days,
+      updated_at: Time.now - rand(50).days
+    }
+  end
+User.import users, validate: false
+ActiveRecord::Base.connection.execute("ANALYZE users")


### PR DESCRIPTION
I have added `if else` statement in the `database_size`, `relation_sizes` and `table_sizes` functions of the `Space` module in order to get the correct sizes of the database, distributed tables and distributed indexes if Citus is enabled. 