### PR TITLE
Add settings for a worker in the Tune tab if citus is enabled

### DIFF
--- a/app/controllers/pg_hero/home_controller.rb
+++ b/app/controllers/pg_hero/home_controller.rb
@@ -258,6 +258,13 @@ module PgHero
     def tune
       @title = "Tune"
       @settings = @database.settings
+      @citus_enabled = @database.citus_enabled?
+      if @citus_enabled
+        @citus_worker_count = @database.citus_worker_count
+        if @citus_worker_count > 0
+          @citus_worker_settings = @database.citus_worker_settings
+        end
+      end
       @autovacuum_settings = @database.autovacuum_settings if params[:autovacuum]
     end
 

--- a/app/views/pg_hero/home/tune.html.erb
+++ b/app/views/pg_hero/home/tune.html.erb
@@ -4,7 +4,11 @@
   <table class="table">
     <thead>
       <tr>
-        <th>Setting</th>
+        <% if @citus_enabled %>
+          <th>Coordinator Setting</th>
+        <% else %>
+          <th>Setting</th>
+        <% end %>        
         <th style="width: 20%;">Value</th>
       </tr>
     </thead>
@@ -17,6 +21,24 @@
       <% end %>
     </tbody>
   </table>
+<% if @citus_enabled && @citus_worker_count > 0 %>
+  <table class="table">
+    <thead>
+      <tr>
+        <th>Worker Setting</th>
+        <th style="width: 20%;">Value</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @citus_worker_settings.each do |citus_worker_setting, value| %>
+        <tr>
+          <td><%= citus_worker_setting %></td>
+          <td><%= value %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>
 
   <p>Check out <%= link_to "PgTune", "https://pgtune.leopard.in.ua/", target: "_blank" %> for recommendations. DB version is <%= @database.server_version.split(" ").first.split(".").first(2).join(".") %>.</p>
 </div>

--- a/lib/pghero.rb
+++ b/lib/pghero.rb
@@ -47,7 +47,7 @@ module PgHero
   class << self
     extend Forwardable
     def_delegators :primary_database, :access_key_id, :analyze, :analyze_tables, :autoindex, :autovacuum_danger,
-      :citus_enabled?, :citus_readable?,
+      :citus_enabled?, :citus_readable?, :citus_worker_count,
       :best_index, :blocked_queries, :connection_sources, :connection_stats,
       :cpu_usage, :create_user, :database_size, :db_instance_identifier, :disable_query_stats, :drop_user,
       :duplicate_indexes, :enable_query_stats, :explain, :historical_query_stats_enabled?, :index_caching,
@@ -55,7 +55,7 @@ module PgHero
       :last_stats_reset_time, :long_running_queries, :maintenance_info, :missing_indexes, :query_stats,
       :query_stats_available?, :query_stats_enabled?, :query_stats_extension_enabled?, :query_stats_readable?,
       :rds_stats, :read_iops_stats, :region, :relation_sizes, :replica?, :replication_lag, :replication_lag_stats,
-      :reset_query_stats, :reset_stats, :running_queries, :secret_access_key, :sequence_danger, :sequences, :settings,
+      :reset_query_stats, :reset_stats, :running_queries, :secret_access_key, :sequence_danger, :sequences, :settings, :citus_worker_settings,
       :slow_queries, :space_growth, :ssl_used?, :stats_connection, :suggested_indexes, :suggested_indexes_by_query,
       :suggested_indexes_enabled?, :system_stats_enabled?, :table_caching, :table_hit_rate, :table_stats,
       :total_connections, :transaction_id_danger, :unused_indexes, :unused_tables, :write_iops_stats

--- a/lib/pghero/methods/citus.rb
+++ b/lib/pghero/methods/citus.rb
@@ -9,6 +9,10 @@ module PgHero
       def citus_readable?
         select_one("SELECT EXISTS(SELECT * FROM pg_extension WHERE extname = 'citus')")
       end
+      
+      def citus_worker_count
+        @citus_worker_count = select_one("SELECT COUNT(*) FROM master_get_active_worker_nodes()")
+      end
     end
   end
 end

--- a/lib/pghero/methods/settings.rb
+++ b/lib/pghero/methods/settings.rb
@@ -1,24 +1,30 @@
 module PgHero
   module Methods
     module Settings
+      def names
+        if server_version_num >= 90500
+          %i(
+            max_connections shared_buffers effective_cache_size work_mem
+            maintenance_work_mem min_wal_size max_wal_size checkpoint_completion_target
+            wal_buffers default_statistics_target
+          )
+        else
+          %i(
+            max_connections shared_buffers effective_cache_size work_mem
+            maintenance_work_mem checkpoint_segments checkpoint_completion_target
+            wal_buffers default_statistics_target
+          )
+        end
+      end
+
       def settings
-        names =
-          if server_version_num >= 90500
-            %i(
-              max_connections shared_buffers effective_cache_size work_mem
-              maintenance_work_mem min_wal_size max_wal_size checkpoint_completion_target
-              wal_buffers default_statistics_target
-            )
-          else
-            %i(
-              max_connections shared_buffers effective_cache_size work_mem
-              maintenance_work_mem checkpoint_segments checkpoint_completion_target
-              wal_buffers default_statistics_target
-            )
-          end
         fetch_settings(names)
       end
 
+      def citus_worker_settings
+        citus_fetch_worker_settings(names)
+      end
+         
       def autovacuum_settings
         fetch_settings %i(autovacuum autovacuum_max_workers autovacuum_vacuum_cost_limit autovacuum_vacuum_scale_factor autovacuum_analyze_scale_factor)
       end
@@ -31,6 +37,10 @@ module PgHero
 
       def fetch_settings(names)
         Hash[names.map { |name| [name, select_one("SHOW #{name}")] }]
+      end
+
+      def citus_fetch_worker_settings(names)
+        Hash[names.map { |name| [name, select_one("SELECT result FROM run_command_on_workers($cmd$ SHOW #{name} $cmd$) LIMIT 1")] }]
       end
     end
   end

--- a/test/basic_test_citus.rb
+++ b/test/basic_test_citus.rb
@@ -12,4 +12,12 @@ class BasicCitusTest < Minitest::Test
   def test_relation_sizes
     assert PgHero.relation_sizes
   end
+
+  def test_citus_worker_count
+  	assert_equal 1, PgHero.citus_worker_count
+  end
+
+  def test_citus_worker_settings
+  	assert PgHero.citus_worker_settings
+  end
 end


### PR DESCRIPTION
I have added 2 more methods in the Settings module in order to fetch one worker's setting (the first one appearing after running command on workers). I have made the necessary UI changes to include the table of settings for one worker and specify the main table as Coordinator settings.