### PR TITLE
Add methods to get workers' connections stats and add them to the UI

### DIFF
--- a/app/controllers/pg_hero/home_controller.rb
+++ b/app/controllers/pg_hero/home_controller.rb
@@ -275,6 +275,15 @@ module PgHero
 
       @connections_by_database = group_connections(@connection_sources, :database)
       @connections_by_user = group_connections(@connection_sources, :user)
+
+      @citus_enabled = @database.citus_enabled?
+      if @citus_enabled
+        @citus_worker_connection_sources = @database.citus_worker_connection_sources
+        @citus_worker_total_connections = @citus_worker_connection_sources.map {|wcs| wcs.sum {|cs| cs[:total_connections]}}
+
+        @citus_worker_connections_by_database = @citus_worker_connection_sources.map {|wcs| group_connections(wcs, :database)}
+        @citus_worker_connections_by_user = @citus_worker_connection_sources.map {|wcs| group_connections(wcs, :user)}
+      end
     end
 
     def maintenance

--- a/app/views/pg_hero/home/connections.html.erb
+++ b/app/views/pg_hero/home/connections.html.erb
@@ -1,5 +1,9 @@
 <div class="content">
   <h1>Connections</h1>
+  
+  <% if @citus_enabled %>
+    <h2>Coordinator</h2>
+  <% end %>
 
   <p><%= pluralize(@total_connections, "connection") %></p>
 
@@ -19,5 +23,28 @@
     </script>
 
     <%= render partial: "connections_table", locals: {connection_sources: @connection_sources} %>
+  <% end %>
+  <% if @citus_enabled %>
+    <% worker_connections = @citus_worker_connections_by_database.zip(@citus_worker_connections_by_user) %>
+    <% chart_count = 3 %>
+    <% worker_connections.each_with_index do |(conn_database, conn_user), index| %>
+      <h2>Worker <%= index + 1 %></h2>
+      <p><%= pluralize(@citus_worker_total_connections[index], "connection") %></p>
+      <h3>By Database</h3>
+
+      <div id="chart-<%= chart_count %>" class="chart" style="height: 260px; line-height: 260px; margin-bottom: 20px;">Loading...</div>
+      <script>
+        new Chartkick.PieChart("chart-<%= chart_count %>", <%= json_escape(conn_database.to_json).html_safe %>);
+      </script>
+      <% chart_count += 1 %>
+      <h3>By User</h3>
+
+      <div id="chart-<%=  chart_count %>" class="chart" style="height: 260px; line-height: 260px; margin-bottom: 20px;">Loading...</div>
+      <script>
+        new Chartkick.PieChart("chart-<%= chart_count %>", <%= json_escape(conn_user.to_json).html_safe %>);
+      </script>
+      <% chart_count += 1 %>  
+      <%= render partial: "connections_table", locals: {connection_sources: @citus_worker_connection_sources[index]} %>
+    <% end %>
   <% end %>
 </div>

--- a/lib/pghero.rb
+++ b/lib/pghero.rb
@@ -48,7 +48,7 @@ module PgHero
     extend Forwardable
     def_delegators :primary_database, :access_key_id, :analyze, :analyze_tables, :autoindex, :autovacuum_danger,
       :citus_enabled?, :citus_readable?, :citus_worker_count,
-      :best_index, :blocked_queries, :connection_sources, :connection_stats,
+      :best_index, :blocked_queries, :connection_sources, :connection_stats, :citus_worker_connection_sources,
       :cpu_usage, :create_user, :database_size, :db_instance_identifier, :disable_query_stats, :drop_user,
       :duplicate_indexes, :enable_query_stats, :explain, :historical_query_stats_enabled?, :index_caching,
       :index_hit_rate, :index_usage, :indexes, :invalid_indexes, :kill, :kill_all, :kill_long_running_queries,

--- a/lib/pghero/methods/connections.rb
+++ b/lib/pghero/methods/connections.rb
@@ -21,6 +21,42 @@ module PgHero
             5 DESC, 1, 2, 3, 4
         SQL
       end
+
+      def citus_worker_connection_sources
+        worker_conn_sources = select_all <<-SQL
+          SELECT
+            result
+          FROM
+            run_command_on_workers($cmd$ SELECT
+                                           json_agg(row_to_json(worker_stat_activity))
+                                         FROM(
+                                           SELECT
+                                             datname AS database,
+                                             usename AS user,
+                                             application_name AS source,
+                                             client_addr AS ip,
+                                             COUNT(*) AS total_connections
+                                           FROM
+                                             pg_stat_activity
+                                           GROUP BY
+                                             1, 2, 3, 4
+                                           ORDER BY
+                                             5 DESC, 1, 2, 3, 4) worker_stat_activity $cmd$)
+        SQL
+
+        worker_conn_sources.map! {|wcs| select_all <<-SQL
+          SELECT
+            database,
+            user,
+            source,
+            ip,
+            total_connections
+          FROM
+            json_to_recordset('#{wcs[:result]}'::json)
+            AS worker_stats("database" name, "user" name, "source" text, "ip" inet, "total_connections" int)
+          SQL
+        }
+      end
     end
   end
 end

--- a/test/basic_test_citus.rb
+++ b/test/basic_test_citus.rb
@@ -20,4 +20,8 @@ class BasicCitusTest < Minitest::Test
   def test_citus_worker_settings
   	assert PgHero.citus_worker_settings
   end
+
+  def test_citus_worker_connection_sources
+    assert PgHero.citus_worker_connection_sources
+  end
 end


### PR DESCRIPTION
I have added two more methods in the `connections.rb` file. Both methods take `citus_nodesno` as an argument and they return the total number of connections and connection sources of each worker. I have added worker connection stats to the UI. 