### PR TITLE
 Make index_hit_rate, index_caching and index_usage methods Citus compatible

### DIFF
--- a/test/basic_test_citus.rb
+++ b/test/basic_test_citus.rb
@@ -40,4 +40,16 @@ class BasicCitusTest < Minitest::Test
   def test_table_stats
     assert PgHero.table_stats
   end
+
+  def test_index_hit_rate
+    assert PgHero.index_hit_rate
+  end
+
+  def test_index_caching
+    assert PgHero.index_caching
+  end
+
+  def test_index_usage
+    assert PgHero.index_usage
+  end
 end


### PR DESCRIPTION
I have modified `index_hit_rate`, `index_caching` and `index_usage` with an `if else` statement depending on `citus_enabled` variable. I am mostly running command on placements for distributed tables. The method currently being used in the project is `index_hit_rate`.