### PR TITLE
Make missing_indexes, unused_indexes and reset_stats Citus compatible

### DIFF
--- a/test/basic_test_citus.rb
+++ b/test/basic_test_citus.rb
@@ -52,4 +52,12 @@ class BasicCitusTest < Minitest::Test
   def test_index_usage
     assert PgHero.index_usage
   end
+
+  def test_missing_indexes
+    assert PgHero.missing_indexes
+  end
+
+  def test_unused_indexes
+    assert PgHero.unused_indexes
+  end
 end

--- a/test/reset_stats_test_citus.rb
+++ b/test/reset_stats_test_citus.rb
@@ -1,0 +1,11 @@
+require_relative "test_citus_helper"
+
+class ResetStatsCitusTest < Minitest::Test
+  def setup
+    PgHero.reset_stats
+  end
+
+  def test_reset_stats
+    assert_equal 0.0, PgHero.index_hit_rate
+  end
+end


### PR DESCRIPTION
I have modified `missing_indexes`, `unused_indexes` and `reset_stats` with an `if else` statement depending on `citus_enabled` variable. I am mostly running command on placements for distributed tables. The method currently being used in the project is `unused_indexes`.