### PR TITLE
Add Cluster Info under Citus tab with version and nodes info

### DIFF
--- a/app/assets/stylesheets/pghero/application.css
+++ b/app/assets/stylesheets/pghero/application.css
@@ -180,7 +180,7 @@ hr {
   padding: 6px 140px 20px 140px;
 }
 
-.queries-table th a, .space-table th a {
+.queries-table th a, .space-table th a, .nodes-table th a {
   color: inherit;
 }
 

--- a/app/controllers/pg_hero/home_controller.rb
+++ b/app/controllers/pg_hero/home_controller.rb
@@ -23,6 +23,7 @@ module PgHero
     def index
       @title = "Overview"
       @extended = params[:extended]
+      @citus_enabled = @database.citus_enabled?
 
       if @replica
         @replication_lag = @database.replication_lag
@@ -66,8 +67,22 @@ module PgHero
       @show_migrations = PgHero.show_migrations
     end
 
+    def cluster_info
+      @title = "Cluster Info"
+      @citus_enabled = @database.citus_enabled?
+      @citus_version = @database.citus_version
+      @nodes_info = @database.nodes_info
+      case params[:sort]
+      when "name"
+        @nodes_info.sort_by! { |n| n[:name] }
+      when "size"
+        @nodes_info.sort_by! { |n| n[:size] }.reverse!
+      end
+    end
+
     def space
       @title = "Space"
+      @citus_enabled = @database.citus_enabled?
       @days = (params[:days] || 7).to_i
       @database_size = @database.database_size
       @relation_sizes = params[:tables] ? @database.table_sizes : @database.relation_sizes
@@ -107,12 +122,14 @@ module PgHero
 
     def live_queries
       @title = "Live Queries"
+      @citus_enabled = @database.citus_enabled?
       @running_queries = @database.running_queries(all: true)
       @vacuum_progress = @database.vacuum_progress.index_by { |q| q[:pid] }
     end
 
     def queries
       @title = "Queries"
+      @citus_enabled = @database.citus_enabled?
       @sort = %w(average_time calls).include?(params[:sort]) ? params[:sort] : nil
       @min_average_time = params[:min_average_time] ? params[:min_average_time].to_i : nil
       @min_calls = params[:min_calls] ? params[:min_calls].to_i : nil
@@ -228,6 +245,7 @@ module PgHero
 
     def explain
       @title = "Explain"
+      @citus_enabled = @database.citus_enabled?
       @query = params[:query]
       # TODO use get + token instead of post so users can share links
       # need to prevent CSRF and DoS
@@ -288,6 +306,7 @@ module PgHero
 
     def maintenance
       @title = "Maintenance"
+      @citus_enabled = @database.citus_enabled?
       @maintenance_info = @database.maintenance_info
       @time_zone = PgHero.time_zone
     end

--- a/app/views/layouts/pg_hero/application.html.erb
+++ b/app/views/layouts/pg_hero/application.html.erb
@@ -31,6 +31,12 @@
           <ul class="nav">
             <!-- poor man's active_link_to -->
             <li class="<%= controller.action_name == "index" ? "active" : "" %>"><%= link_to "Overview", root_path %></li>
+            <% if @citus_enabled %>
+              <li><a href="#" onclick="var x = document.getElementById('citus'); if (x.style.display === 'none') { x.style.display = 'block'; } else { x.style.display = 'none';} this.textContent = this.textContent == 'Citus &#9662;' ? 'Citus &#9663;' : 'Citus &#9662;';">Citus &#9662;</a></li>
+              <div id = "citus" style = "display: none; background-color: #fff;">
+                <li class="<%= controller.action_name == "cluster_info" ? "active" : "" %>"><%= link_to "Cluster Info", cluster_info_path %></li>
+              </div>
+            <% end %>
             <% if @system_stats_enabled %>
               <li class="<%= controller.action_name == "system" ? "active" : "" %>"><%= link_to "System", system_path %></li>
             <% end %>

--- a/app/views/pg_hero/home/cluster_info.html.erb
+++ b/app/views/pg_hero/home/cluster_info.html.erb
@@ -1,0 +1,59 @@
+<div class="content">
+  <h1>Cluster Info</h1>
+    <p>Citus Version: <%= @citus_version %></p>
+  <h3>Worker Nodes</h3>
+  <table class="table nodes-table">
+    <thead>
+      <tr>
+        <th style="width: 8%;"><%= link_to "ID", {} %></th>
+        <th colspan="3"><%= link_to "Name", {sort: "name"} %></th>
+        <th>Port</th>
+        <th>Role</th>
+        <th>Status</th>
+        <th>Shards</th>
+        <th><%= link_to "Size", {sort: "size"} %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @nodes_info.each do |node_info| %>
+        <tr>
+          <td style="width: 8%;">
+            <span style="word-break: break-all;">
+              <%= number_with_delimiter(node_info[:id]) %>
+            </span>
+          </td>
+          <td colspan = 3>
+            <span style="word-break: break-all;">
+              <%= node_info[:name] %>
+            </span>
+          </td>
+          <td>
+            <span style="word-break: break-all;">
+              <%= node_info[:port] %>
+            </span>
+          </td>
+          <td>
+            <span style="word-break: break-all;">
+              <%= node_info[:role] %>
+            </span>
+          </td>
+          <td>
+            <span style="word-break: break-all;">
+              <%= node_info[:status] ? 'active' : 'inactive' %>
+            </span>
+          </td>
+          <td>
+            <span style="word-break: break-all;">
+              <%= number_with_delimiter(node_info[:shard_count]) %>
+            </span>
+          </td>
+          <td>
+            <span style="word-break: break-all;">
+              <%= PgHero.pretty_size(node_info[:size]) %>
+            </span>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 PgHero::Engine.routes.draw do
   scope "(:database)", constraints: proc { |req| (PgHero.config["databases"].keys + [nil]).include?(req.params[:database]) } do
+    get "cluster_info", to: "home#cluster_info"
     get "space", to: "home#space"
     get "space/:relation", to: "home#relation_space", as: :relation_space
     get "index_bloat", to: "home#index_bloat"

--- a/lib/pghero.rb
+++ b/lib/pghero.rb
@@ -47,7 +47,7 @@ module PgHero
   class << self
     extend Forwardable
     def_delegators :primary_database, :access_key_id, :analyze, :analyze_tables, :autoindex, :autovacuum_danger,
-      :citus_enabled?, :citus_readable?, :citus_worker_count,
+      :citus_enabled?, :citus_readable?, :citus_worker_count, :citus_version, :nodes_info,
       :best_index, :blocked_queries, :connection_sources, :connection_stats, :citus_worker_connection_sources,
       :cpu_usage, :create_user, :database_size, :db_instance_identifier, :disable_query_stats, :drop_user,
       :duplicate_indexes, :enable_query_stats, :explain, :historical_query_stats_enabled?, :index_caching,

--- a/lib/pghero/methods/citus.rb
+++ b/lib/pghero/methods/citus.rb
@@ -9,9 +9,57 @@ module PgHero
       def citus_readable?
         select_one("SELECT EXISTS(SELECT * FROM pg_extension WHERE extname = 'citus')")
       end
-      
+
       def citus_worker_count
         @citus_worker_count = select_one("SELECT COUNT(*) FROM master_get_active_worker_nodes()")
+      end
+
+      def citus_version
+        @citus_version ||= select_one("SHOW citus.version")
+      end
+
+      def nodes_info
+        select_all <<-SQL
+          WITH node_sizes AS (
+            SELECT
+              nodename,
+              nodeport,
+              result
+            FROM
+              run_command_on_workers($$ SELECT pg_database_size(current_database()) $$)
+          ),
+          dist_nodes AS (
+            SELECT
+              nodeid,
+              nodename,
+              nodeport,
+              noderole,
+              isactive,
+              count(*) AS shard_count
+            FROM
+              pg_dist_placement p,
+              pg_dist_node n
+            WHERE
+              p.groupid = n.groupid
+            GROUP BY
+              1, 2, 3, 4, 5
+          )
+          SELECT
+            nodeid AS id,
+            n.nodename AS name,
+            n.nodeport AS port,
+            noderole AS role,
+            isactive AS status,
+            shard_count,
+            result AS size
+          FROM
+            node_sizes s,
+            dist_nodes n
+          WHERE
+            s.nodename = n.nodename AND s.nodeport = n.nodeport
+          ORDER BY
+            1
+        SQL
       end
     end
   end

--- a/test/basic_test_citus.rb
+++ b/test/basic_test_citus.rb
@@ -68,4 +68,12 @@ class BasicCitusTest < Minitest::Test
   def test_maintenance_info
     assert PgHero.maintenance_info
   end
+
+  def test_citus_version
+    assert PgHero.citus_version
+  end
+
+  def test_nodes_info
+    assert PgHero.nodes_info
+  end
 end


### PR DESCRIPTION
I have added `citus_version` and `nodes_info` methods in `Citus` module. I have created another controller for **Cluster Info** tab. In the UI, I have created a drop-down menu called **Citus** with currently only the **Cluster Info** option. The new tab has Citus version and a nodes table.