### PR TITLE
Add Data Distribution under Citus tab with shard colocation groups

### DIFF
--- a/app/assets/stylesheets/pghero/application.css
+++ b/app/assets/stylesheets/pghero/application.css
@@ -180,7 +180,7 @@ hr {
   padding: 6px 140px 20px 140px;
 }
 
-.queries-table th a, .space-table th a, .nodes-table th a {
+.queries-table th a, .space-table th a, .nodes-table th a, .colocations-table th a {
   color: inherit;
 }
 

--- a/app/controllers/pg_hero/home_controller.rb
+++ b/app/controllers/pg_hero/home_controller.rb
@@ -80,6 +80,16 @@ module PgHero
       end
     end
 
+    def data_distribution
+      @title = "Data Distribution"
+      @citus_enabled = @database.citus_enabled?
+      @colocated_shard_sizes = @database.colocated_shard_sizes
+      case params[:sort]
+      when "colocated_shards_size"
+        @colocated_shard_sizes.sort_by! { |c| c[:colocated_shards_size] }.reverse!
+      end
+    end
+
     def space
       @title = "Space"
       @citus_enabled = @database.citus_enabled?

--- a/app/views/layouts/pg_hero/application.html.erb
+++ b/app/views/layouts/pg_hero/application.html.erb
@@ -35,6 +35,7 @@
               <li><a href="#" onclick="var x = document.getElementById('citus'); if (x.style.display === 'none') { x.style.display = 'block'; } else { x.style.display = 'none';} this.textContent = this.textContent == 'Citus &#9662;' ? 'Citus &#9663;' : 'Citus &#9662;';">Citus &#9662;</a></li>
               <div id = "citus" style = "display: none; background-color: #fff;">
                 <li class="<%= controller.action_name == "cluster_info" ? "active" : "" %>"><%= link_to "Cluster Info", cluster_info_path %></li>
+                <li class="<%= controller.action_name == "data_distribution" ? "active" : "" %>"><%= link_to "Data Distribution", data_distribution_path %></li>
               </div>
             <% end %>
             <% if @system_stats_enabled %>

--- a/app/views/pg_hero/home/data_distribution.html.erb
+++ b/app/views/pg_hero/home/data_distribution.html.erb
@@ -1,0 +1,59 @@
+<div class="content">
+  <h1>Data Distribution</h1>
+  <h3>Shard Colocation Groups</h3>
+  <p><b><span style="color: #09436a;">NOTE: </span></b>The colocations include only shards of the tables that are <em>hash</em> distributed.</p>
+  <table class="table colocations-table">
+    <thead>
+      <tr>
+        <th style="width: 10%;"><%= link_to "Node ID", {} %></th>
+        <th style="width: 22%;"><%= link_to "Coloc. Group Size", {sort: "colocated_shards_size"} %></th>
+        <th style = "padding: 0px;">
+          <table style="margin-bottom: 0px; color: inherit;" cellpadding="0" cellspacing="0">
+            <tr>
+              <th style="border-bottom: none;" colspan = "3">Shard Names</th>
+              <th style="border-bottom: none;">Shard Sizes</th>
+            </tr>
+          </table>
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @colocated_shard_sizes.each do |colocated_shards| %>
+        <% shard_names = colocated_shards[:shard_group].delete('{}').split(',') %>
+        <% shard_sizes = colocated_shards[:each_shard_size].delete('{}').split(',') %>
+        <% shards = shard_names.zip(shard_sizes).to_h %>
+        <% shards = shards.sort.to_h %>
+        <tr>
+          <td style="width: 10%;">
+            <span style="word-break: break-all;">
+              <%= number_with_delimiter(colocated_shards[:nodeid]) %>
+            </span>
+          </td>
+          <td style="width: 22%;">
+            <span style="word-break: break-all;">
+              <%= PgHero.pretty_size(colocated_shards[:colocated_shards_size]) %>
+            </span>
+          </td>
+          <td style = "padding: 0px;">
+            <table style="margin-bottom: 0px; color: inherit;" cellpadding="0" cellspacing="0">
+              <% shards.each do |name, size| %>
+                <tr>
+                  <td style = "border-top: none;" colspan = "3">
+                    <span style="word-break: break-all;">
+                      <%= name %>
+                    </span>
+                  </td>
+                  <td style = "border-top: none;">
+                    <span style="word-break: break-all;">
+                      <%= PgHero.pretty_size(size) %>
+                    </span>
+                  </td>
+                </tr>
+              <% end %>
+            </table>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 PgHero::Engine.routes.draw do
   scope "(:database)", constraints: proc { |req| (PgHero.config["databases"].keys + [nil]).include?(req.params[:database]) } do
     get "cluster_info", to: "home#cluster_info"
+    get "data_distribution", to:"home#data_distribution"
     get "space", to: "home#space"
     get "space/:relation", to: "home#relation_space", as: :relation_space
     get "index_bloat", to: "home#index_bloat"

--- a/lib/pghero.rb
+++ b/lib/pghero.rb
@@ -47,7 +47,7 @@ module PgHero
   class << self
     extend Forwardable
     def_delegators :primary_database, :access_key_id, :analyze, :analyze_tables, :autoindex, :autovacuum_danger,
-      :citus_enabled?, :citus_readable?, :citus_worker_count, :citus_version, :nodes_info,
+      :citus_enabled?, :citus_readable?, :citus_worker_count, :citus_version, :nodes_info, :colocated_shard_sizes,
       :best_index, :blocked_queries, :connection_sources, :connection_stats, :citus_worker_connection_sources,
       :cpu_usage, :create_user, :database_size, :db_instance_identifier, :disable_query_stats, :drop_user,
       :duplicate_indexes, :enable_query_stats, :explain, :historical_query_stats_enabled?, :index_caching,

--- a/test/basic_test_citus.rb
+++ b/test/basic_test_citus.rb
@@ -76,4 +76,8 @@ class BasicCitusTest < Minitest::Test
   def test_nodes_info
     assert PgHero.nodes_info
   end
+
+  def test_colocated_shard_sizes
+    assert PgHero.colocated_shard_sizes
+  end
 end


### PR DESCRIPTION
I have added `colocated_shard_sizes` method in `Citus` module. I have created another controller for **Data Distribution** tab (added option in **Citus** drop-down menu). This new tab has shard colocation groups depicted in a table, queried by `colocated_shard_sizes` method.