### PR TITLE
 Add data distribution by shards depiction

### DIFF
--- a/app/assets/javascripts/pghero/application.js
+++ b/app/assets/javascripts/pghero/application.js
@@ -148,3 +148,12 @@ function initSlider() {
     refreshStats(false);
   });
 }
+
+function initDetailPanes() {
+  $("tr.details").click(function() {
+    var $tr = $(this).next();
+    $tr.toggle(function() {
+      $(this).find("> td > div").slideToggle();
+    });
+  });
+}

--- a/app/assets/stylesheets/pghero/application.css
+++ b/app/assets/stylesheets/pghero/application.css
@@ -85,6 +85,13 @@ td {
   vertical-align: top;
 }
 
+tr.details {
+  cursor: pointer;
+}
+ tr.details + tr {
+  display: none;
+}
+
 pre {
   background-color: #eee;
   padding: 10px;

--- a/app/controllers/pg_hero/home_controller.rb
+++ b/app/controllers/pg_hero/home_controller.rb
@@ -83,6 +83,10 @@ module PgHero
     def data_distribution
       @title = "Data Distribution"
       @citus_enabled = @database.citus_enabled?
+      @distributed_tables = @database.distributed_tables
+      @distributed_tables.each do |distributed_table|
+        distributed_table[:shards] = @database.shard_data_distribution(distributed_table[:logicalrelid], distributed_table[:partition_column])
+      end
       @colocated_shard_sizes = @database.colocated_shard_sizes
       case params[:sort]
       when "colocated_shards_size"

--- a/app/views/pg_hero/home/data_distribution.html.erb
+++ b/app/views/pg_hero/home/data_distribution.html.erb
@@ -1,5 +1,58 @@
 <div class="content">
   <h1>Data Distribution</h1>
+  <h3>Shards</h3>
+  <p><b>Click</b> distributed table's row to see data distribution in its shards.</p>
+  <table class="table space-table">
+    <thead>
+      <tr>
+        <th>Distributed Table</th>
+        <th style="width: 15%;">Size</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @distributed_tables.each do |dist_table| %>
+        <tr class = "details">
+          <td>
+            <span style="word-break: break-all;">
+              <%= dist_table[:dist_table_name] %>
+            </span>
+            <% if dist_table[:schema] != "public" %>
+              <span class="text-muted"><%= dist_table[:schema] %></span>
+            <% end %>
+          </td>
+          <td style="width: 15%;">
+            <span style="word-break: break-all;">
+              <%= PgHero.pretty_size(dist_table[:size_bytes]) %>
+            </span>
+          </td>
+          <tr>
+            <td colspan="2">
+              <div align=center style="display:none">
+                <table style="width: 75%;">
+                  <thead>
+                    <tr style="color: #09436a; background: #239f49">
+                      <th style="width: 20%;">Node ID</th>
+                      <th>Shard ID</th>
+                      <th>Shard Size</th>
+                      <th style="width: 24%;">Tenant Count</th>
+                    </tr>
+                  </thead>
+                  <% dist_table[:shards].each do |shard| %>
+                    <tr>
+                      <td style="width: 20%;"><%= shard[:nodeid] %></td>
+                      <td><%= '#' + shard[:id].to_s %></td>
+                      <td><%= PgHero.pretty_size(shard[:size_bytes]) %></td>
+                      <td style="width: 24%;"><%= shard[:tenant_count] %></td>                   
+                    </tr>
+                  <% end %>
+                </table>
+              </div>
+            </td>
+          </tr>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
   <h3>Shard Colocation Groups</h3>
   <p><b><span style="color: #09436a;">NOTE: </span></b>The colocations include only shards of the tables that are <em>hash</em> distributed.</p>
   <table class="table colocations-table">
@@ -57,3 +110,6 @@
     </tbody>
   </table>
 </div>
+<script>
+  initDetailPanes();
+</script>

--- a/lib/pghero.rb
+++ b/lib/pghero.rb
@@ -48,7 +48,7 @@ module PgHero
     extend Forwardable
     def_delegators :primary_database, :access_key_id, :analyze, :analyze_tables, :autoindex, :autovacuum_danger,
       :citus_enabled?, :citus_readable?, :citus_worker_count, :citus_version, :nodes_info, :colocated_shard_sizes,
-      :landlord_available?, :landlord_stats, :reset_landlord_stats,
+      :landlord_available?, :landlord_stats, :reset_landlord_stats, :distributed_tables, :shard_data_distribution,
       :best_index, :blocked_queries, :connection_sources, :connection_stats, :citus_worker_connection_sources,
       :cpu_usage, :create_user, :database_size, :db_instance_identifier, :disable_query_stats, :drop_user,
       :duplicate_indexes, :enable_query_stats, :explain, :historical_query_stats_enabled?, :index_caching,

--- a/test/basic_test_citus.rb
+++ b/test/basic_test_citus.rb
@@ -80,4 +80,12 @@ class BasicCitusTest < Minitest::Test
   def test_colocated_shard_sizes
     assert PgHero.colocated_shard_sizes
   end
+
+  def test_distributed_tables
+    assert PgHero.distributed_tables
+  end
+
+  def test_shard_data_distribution
+    assert PgHero.shard_data_distribution('users', 'id')
+  end
 end


### PR DESCRIPTION
I have added `distributed_tables` and `shard_data_distribution` methods in `Citus` module. Also I have added `initDetailPanes` function in `application.js` that allows to give details about a table's row when clicked. **Data Distribution** tab now has another table for distribution in each distributed table's shards.