### PR TITLE
 Add distributed tables table view in cluster info tab

### DIFF
--- a/app/controllers/pg_hero/home_controller.rb
+++ b/app/controllers/pg_hero/home_controller.rb
@@ -72,11 +72,16 @@ module PgHero
       @citus_enabled = @database.citus_enabled?
       @citus_version = @database.citus_version
       @nodes_info = @database.nodes_info
+      @dist_tables_extended = @database.dist_tables_extended
       case params[:sort]
       when "name"
         @nodes_info.sort_by! { |n| n[:name] }
       when "size"
         @nodes_info.sort_by! { |n| n[:size] }.reverse!
+      when "dist_table_name"
+        @dist_tables_extended.sort_by! {|p| p[:dist_table_name]}
+      when "part_size"
+        @dist_tables_extended.sort_by! {|p| p[:part_size]}.reverse!
       end
     end
 

--- a/app/views/pg_hero/home/cluster_info.html.erb
+++ b/app/views/pg_hero/home/cluster_info.html.erb
@@ -1,6 +1,6 @@
 <div class="content">
   <h1>Cluster Info</h1>
-    <p>Citus Version: <%= @citus_version %></p>
+    <p><b>Citus Version: <%= @citus_version %></b></p>
   <h3>Worker Nodes</h3>
   <table class="table nodes-table">
     <thead>
@@ -50,6 +50,59 @@
           <td>
             <span style="word-break: break-all;">
               <%= PgHero.pretty_size(node_info[:size]) %>
+            </span>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+  <h3>Distributed Tables</h3>
+  <p><b><span style="color: #09436a;">NOTE: </span></b><em>Size</em> stands for all the disk space used by the shards of the table, including all indexes.</p>
+  <table class="table nodes-table">
+    <thead>
+      <tr>
+        <th style="width: 11%;"><%= link_to "Coloc. ID", {} %></th>
+        <th colspan = 2><%= link_to "Name", {sort: "dist_table_name"} %></th>
+        <th>Dist. Method</th>
+        <th>Dist. Column</th>
+        <th style="width: 11%;">Shards</th>
+        <th style="width: 12%;"><%= link_to "Size", {sort: "part_size"} %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @dist_tables_extended.each do |dist_table| %>
+        <tr>
+          <td style="width: 11%;">
+            <span style="word-break: break-all;">
+              <%= number_with_delimiter(dist_table[:coloc_id]) %>
+            </span>
+          </td>
+          <td colspan = 2>
+            <span style="word-break: break-all;">
+              <%= dist_table[:dist_table_name] %>
+            </span>
+            <% if dist_table[:schema] != "public" %>
+              <span class="text-muted"><%= dist_table[:schema] %></span>
+            <% end %>
+          </td>
+          <td>
+            <span style="word-break: break-all;">
+              <%= dist_table[:partmethod] %>
+            </span>
+          </td>
+          <td>
+            <span style="word-break: break-all;">
+              <%= dist_table[:partition_column] %>
+            </span>
+          </td>
+          <td style="width: 11%;">
+            <span style="word-break: break-all;">
+              <%= dist_table[:shard_count] %>
+            </span>
+          </td>
+          <td style="width: 12%;">
+            <span style="word-break: break-all;">
+              <%= PgHero.pretty_size(dist_table[:part_size]) %>
             </span>
           </td>
         </tr>

--- a/lib/pghero.rb
+++ b/lib/pghero.rb
@@ -48,7 +48,7 @@ module PgHero
     extend Forwardable
     def_delegators :primary_database, :access_key_id, :analyze, :analyze_tables, :autoindex, :autovacuum_danger,
       :citus_enabled?, :citus_readable?, :citus_worker_count, :citus_version, :nodes_info, :colocated_shard_sizes,
-      :landlord_available?, :landlord_stats, :reset_landlord_stats, :distributed_tables, :shard_data_distribution,
+      :landlord_available?, :landlord_stats, :reset_landlord_stats, :distributed_tables, :shard_data_distribution, :dist_tables_extended,
       :best_index, :blocked_queries, :connection_sources, :connection_stats, :citus_worker_connection_sources,
       :cpu_usage, :create_user, :database_size, :db_instance_identifier, :disable_query_stats, :drop_user,
       :duplicate_indexes, :enable_query_stats, :explain, :historical_query_stats_enabled?, :index_caching,

--- a/lib/pghero/methods/citus.rb
+++ b/lib/pghero/methods/citus.rb
@@ -195,6 +195,26 @@ module PgHero
             1, 4 DESC
         SQL
       end
+
+      def dist_tables_extended
+        select_all <<-SQL
+          SELECT
+            colocationid AS coloc_id,
+            schemaname AS schema,
+            tablename AS dist_table_name,
+            CASE WHEN partmethod != 'n' THEN 'distributed' ELSE 'reference' END AS partmethod,
+            CASE WHEN partmethod != 'n' THEN column_to_column_name(logicalrelid, partkey) ELSE '-' END AS partition_column,
+            (SELECT count(*) FROM run_command_on_shards(logicalrelid, 'SELECT 1')) AS shard_count,
+            citus_total_relation_size(logicalrelid) AS part_size
+          FROM
+            pg_dist_partition
+          JOIN
+            pg_tables
+            ON logicalrelid = (schemaname || '.' || tablename)::regclass
+          ORDER BY
+            1, 3, 2 DESC
+        SQL
+      end
     end
   end
 end

--- a/test/basic_test_citus.rb
+++ b/test/basic_test_citus.rb
@@ -88,4 +88,8 @@ class BasicCitusTest < Minitest::Test
   def test_shard_data_distribution
     assert PgHero.shard_data_distribution('users', 'id')
   end
+
+  def test_dist_tables_extended
+    assert PgHero.dist_tables_extended
+  end
 end


### PR DESCRIPTION
I have added `partitioned_tables` method in `Citus` module. Since the name _Partitioned Tables_ was misleading, I didn't include it in the UI but I left this method name in order to distinguish it from `distributed_tables` method used in **Data Distribution** (which doesn't include reference tables and doesn't do the work of running command on shards to get shard count). A table with this info is added in **Cluster Info** tab.