### PR TITLE
Identify node by id in Connections, add node_sizes and partmethod in Space

### DIFF
--- a/app/controllers/pg_hero/home_controller.rb
+++ b/app/controllers/pg_hero/home_controller.rb
@@ -144,6 +144,9 @@ module PgHero
       @show_migrations = PgHero.show_migrations
       @system_stats_enabled = @database.system_stats_enabled?
       @index_bloat = [] # @database.index_bloat
+      if @citus_enabled
+        @node_sizes = @database.node_sizes
+      end
     end
 
     def relation_space

--- a/app/views/pg_hero/home/connections.html.erb
+++ b/app/views/pg_hero/home/connections.html.erb
@@ -28,7 +28,7 @@
     <% worker_connections = @citus_worker_connections_by_database.zip(@citus_worker_connections_by_user) %>
     <% chart_count = 3 %>
     <% worker_connections.each_with_index do |(conn_database, conn_user), index| %>
-      <h2>Worker <%= index + 1 %></h2>
+      <h2>Worker Node <%= @citus_worker_connection_sources[index].first[:nodeid] %></h2>
       <p><%= pluralize(@citus_worker_total_connections[index], "connection") %></p>
       <h3>By Database</h3>
 

--- a/app/views/pg_hero/home/space.html.erb
+++ b/app/views/pg_hero/home/space.html.erb
@@ -1,7 +1,13 @@
 <div class="content">
   <h1>Space</h1>
 
-  <p>Database Size: <%= @database_size %></p>
+  <p>Total Database Size: <%= @database_size %></p>
+  <% if @citus_enabled %>
+    <% @node_sizes.each do |node| %>
+      <p><%= node[:name] %> Size: <%= PgHero.pretty_size(node[:size]) %></p>
+    <% end %>
+    <br>
+  <% end %>
 
   <% if @system_stats_enabled %>
     <div id="chart-1" class="chart" style="margin-bottom: 20px;">Loading...</div>
@@ -61,6 +67,9 @@ remove_index <%= query[:table].to_sym.inspect %>, name: <%= query[:index].to_s.i
             </span>
             <% if query[:schema] != "public" %>
               <span class="text-muted"><%= query[:schema] %></span>
+            <% end %>
+            <% if query[:partmethod] != "-" %>
+              <span style="color: #239f49;"><em> <%= query[:partmethod] %> </em></span>
             <% end %>
             <% if @unused_index_names.include?(query[:relation]) %>
               <span class="unused-index">UNUSED</span>

--- a/test/basic_test_citus.rb
+++ b/test/basic_test_citus.rb
@@ -92,4 +92,8 @@ class BasicCitusTest < Minitest::Test
   def test_dist_tables_extended
     assert PgHero.dist_tables_extended
   end
+
+  def test_node_sizes
+    assert PgHero.node_sizes
+  end
 end


### PR DESCRIPTION
I have added `node_sizes` method in `Citus` module. I have modified the `relation_sizes` method in `Space` module in order to include the column of `partmethod`. I give separate node sizes in **Space** tab. I have saved `nodeid` in order to identify worker nodes in the **Connections** tab.