### PR TITLE
 Add Configuration under Citus tab with Citus config. settings

### DIFF
--- a/app/controllers/pg_hero/home_controller.rb
+++ b/app/controllers/pg_hero/home_controller.rb
@@ -120,6 +120,12 @@ module PgHero
       end
     end
 
+    def citus_settings
+      @title = "Settings"
+      @citus_enabled = @database.citus_enabled?
+      @citus_settings = @database.citus_settings
+    end
+
     def space
       @title = "Space"
       @citus_enabled = @database.citus_enabled?

--- a/app/views/layouts/pg_hero/application.html.erb
+++ b/app/views/layouts/pg_hero/application.html.erb
@@ -37,6 +37,7 @@
                 <li class="<%= controller.action_name == "cluster_info" ? "active" : "" %>"><%= link_to "Cluster Info", cluster_info_path %></li>
                 <li class="<%= controller.action_name == "data_distribution" ? "active" : "" %>"><%= link_to "Data Distribution", data_distribution_path %></li>
                 <li class="<%= controller.action_name == "landlord" ? "active" : "" %>"><%= link_to "Landlord", landlord_path %></li>
+                <li class="<%= controller.action_name == "citus_settings" ? "active" : "" %>"><%= link_to "Configuration", citus_settings_path %></li>
               </div>
             <% end %>
             <% if @system_stats_enabled %>

--- a/app/views/pg_hero/home/citus_settings.html.erb
+++ b/app/views/pg_hero/home/citus_settings.html.erb
@@ -1,0 +1,22 @@
+<div class="content">
+  <h1>Configuration</h1>
+
+  <table class="table">
+    <thead>
+      <tr>
+        <th>Citus Setting</th>     
+        <th style="width: 30%;">Value</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @citus_settings.each do |citus_setting, value| %>
+        <tr>
+          <td><%= citus_setting %></td>
+          <td><%= value %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <p>Check out <%= link_to "Citus Configuration Reference", "http://docs.citusdata.com/en/v7.5/develop/api_guc.html", target: "_blank" %> for recommendations.</p>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ PgHero::Engine.routes.draw do
     get "cluster_info", to: "home#cluster_info"
     get "data_distribution", to:"home#data_distribution"
     get "landlord", to:"home#landlord"
+    get "citus_settings", to:"home#citus_settings"
     get "space", to: "home#space"
     get "space/:relation", to: "home#relation_space", as: :relation_space
     get "index_bloat", to: "home#index_bloat"

--- a/lib/pghero/methods/citus.rb
+++ b/lib/pghero/methods/citus.rb
@@ -215,6 +215,48 @@ module PgHero
             1, 3, 2 DESC
         SQL
       end
+
+      def citus_settings
+        names =
+            %i(
+                  citus.max_worker_nodes_tracked
+                  citus.use_secondary_nodes
+                  citus.cluster_name
+                  citus.enable_version_checks
+                  citus.log_distributed_deadlock_detection
+                  citus.distributed_deadlock_detection_factor
+                  citus.multi_shard_commit_protocol
+                  citus.shard_replication_factor
+                  citus.shard_count
+                  citus.shard_max_size
+                  citus.limit_clause_row_fetch_count
+                  citus.count_distinct_error_rate
+                  citus.task_assignment_policy
+                  citus.binary_worker_copy_format
+                  citus.binary_master_copy_format
+                  citus.max_intermediate_result_size
+                  citus.enable_ddl_propagation
+                  citus.all_modifications_commutative
+                  citus.max_task_string_size
+                  citus.remote_task_check_interval
+                  citus.task_executor_type
+                  citus.multi_task_query_log_level
+                  citus.enable_repartition_joins
+                  citus.task_tracker_delay
+                  citus.max_tracked_tasks_per_node
+                  citus.max_assign_task_batch_size
+                  citus.max_running_tasks_per_node
+                  citus.partition_buffer_size
+                  citus.explain_all_tasks
+            )
+         citus_fetch_settings(names)
+      end
+
+      private
+
+      def citus_fetch_settings(names)
+        Hash[names.map { |name| [name[6..-1], select_one("SHOW #{name}")] }]
+      end
     end
   end
 end

--- a/test/basic_test_citus.rb
+++ b/test/basic_test_citus.rb
@@ -96,4 +96,8 @@ class BasicCitusTest < Minitest::Test
   def test_node_sizes
     assert PgHero.node_sizes
   end
+
+  def test_citus_settings
+    assert PgHero.citus_settings
+  end
 end


### PR DESCRIPTION
I have added `citus_settings` and `citus_fetch_settings` in `Citus` module. I have created another controller for **Configuration** tab (added option in **Citus** drop-down menu). This new tab shows Citus settings.